### PR TITLE
[ Feat/notion api ] 프로젝트 분류 탭 지정 및 노션 데이터 타입지정 및 테스트

### DIFF
--- a/src/app/notion/page.tsx
+++ b/src/app/notion/page.tsx
@@ -1,42 +1,28 @@
 'use client'
-import { useNotionApi } from '@/hooks/useNotionApi'
+import { ProjectCard } from '@/components/ProjectCard'
+import { useNotionApi, useNotionProjectNotes, useNotionProjectNotesTabs } from '@/hooks/useNotionApi'
 import Link from 'next/link'
+import { useState } from 'react'
 
 export default function NotionPreview() {
-  const { notes, error, loading } = useNotionApi()
+
+  const { projectNotes, loading,  error, } = useNotionProjectNotes('test')
 
   if (loading) return <p>로딩 중...</p>
   if (error) return <p>{error}</p>
+
 return (
     <div className="p-4">
       <h2 className="font-bold text-lg mb-3">📄 Notion 데이터</h2>
-
-      {notes.length === 0 ? (
-        <p>데이터가 없습니다.</p>
-      ) : (
-        <ul className="space-y-2">
-          {notes.map((note) => (
-            <li
-              key={note.id}
-              className="p-3 border rounded-md bg-gray-50 hover:bg-gray-100 transition"
-            >
-                <Link
-                  href={`/notion/${note.id}`}
-                  className="text-blue-600 hover:underline"
-                >
-                {note.properties?.title?.title?.[0]?.plain_text ?? '제목 없음'}
-              </Link>
-              <p className="font-semibold">
-                {note.properties?.type?.multi_select?.[0]?.name ?? '태그'}
-                {note.properties?.type?.multi_select?.[0]?.color ?? '컬러'}
-              </p>
-              <p className="font-semibold">
-                <img src={note.properties?.file?.files?.[0]?.file.url ?? '이미지'} alt={note.properties?.file?.files?.[0]?.name ?? '이미지'} />
-              </p>
-            </li>
-          ))}
-        </ul>
-      )}
+      <Link
+        href={`/notion`}
+        className="text-blue-600 hover:underline"
+      >노션페이지 바로가기 
+      </Link>
+      <br />
+      {projectNotes.map(page => (
+        <ProjectCard key={page.id} page={page} />
+      ))}
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,19 @@
 'use client'
 
+import { ProjectCard } from '@/components/ProjectCard'
+import {  useNotionProjectNotesTabs } from '@/hooks/useNotionApi'
 import Link from 'next/link'
+import { useState } from 'react'
 
 export default function NotionPreview() {
 
+  const { tabs, groupedNotes, loading, error } = useNotionProjectNotesTabs('PROJECT')
+  const [activeTab, setActiveTab] = useState<string>(tabs[0] || '')
+
+  if (loading) return <p>로딩 중...</p>
+  if (error) return <p>{error}</p>
+
+  console.log('Notion Notes:', groupedNotes, activeTab);
 return (
     <div className="p-4">
       <h2 className="font-bold text-lg mb-3">📄 Notion 데이터</h2>
@@ -12,6 +22,13 @@ return (
         className="text-blue-600 hover:underline"
       >노션페이지 바로가기 
       </Link>
+      <br />
+      {tabs.map(tab => (
+        <button key={tab} className='px-2 py-1' onClick={() => setActiveTab(tab)}>{tab}</button>
+      ))}
+      {activeTab && groupedNotes[activeTab as keyof typeof groupedNotes].map(page => (
+        <ProjectCard key={page.id} page={page} />
+      ))}
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,9 +26,11 @@ return (
       {tabs.map(tab => (
         <button key={tab} className='px-2 py-1' onClick={() => setActiveTab(tab)}>{tab}</button>
       ))}
-      {activeTab && groupedNotes[activeTab as keyof typeof groupedNotes].map(page => (
-        <ProjectCard key={page.id} page={page} />
-      ))}
+      <div className="flex flex-wrap my-4">
+        {activeTab && groupedNotes[activeTab as keyof typeof groupedNotes].map(page => (
+          <ProjectCard key={page.id} page={page} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/NotionBlocks.tsx
+++ b/src/components/NotionBlocks.tsx
@@ -2,34 +2,35 @@ import { RenderBlock } from '@/utils/notionToMarkdown';
 import Link from 'next/link';
 import React from 'react';
 import clsx from 'clsx';
+import { Block, BlockType, CalloutBlockData, CodeBlockData, HeadingBlockData, ImageBlockData, ListItemBlockData, ParagraphBlockData, QuoteBlockData, TableBlockData, TextBlockProps, ToDoBlockData, ToggleBlockData, VideoBlockData } from './NotionBlocks.type';
 
-export const ParagraphBlock = ({ Block,BlockType,Blockdata }) => {
+
+export const ParagraphBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<ParagraphBlockData>) => {
     return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="div" className='leading-9'/>
-};
-
-export const Heading1Block = ({ Block,BlockType,Blockdata }) => {
+}
+export const Heading1Block = ({ Block,BlockType,Blockdata }: TextBlockProps<HeadingBlockData>) => {
     return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="h1" className='leading-9' />
 }
-export const Heading2Block = ({ Block,BlockType,Blockdata }) => {
+export const Heading2Block = ({ Block,BlockType,Blockdata }: TextBlockProps<HeadingBlockData>) => {
   return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="h2" className='leading-9' />
 }
-export const Heading3Block = ({ Block,BlockType,Blockdata }) => {
+export const Heading3Block = ({ Block,BlockType,Blockdata }: TextBlockProps<HeadingBlockData>) => {
   return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="h4" className='leading-9'/>
 }
-export const BulletedListItemBlock = ({ Block,BlockType,Blockdata }) => {
+export const BulletedListItemBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<ListItemBlockData>) => {
   return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="span" TagClass='list-item ml-6 leading-7'/>
 }
-export const NumberedListItemBlock = ({ Block,BlockType,Blockdata }) => {
+export const NumberedListItemBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<ListItemBlockData>) => {
   return <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="span" TagClass='list-item ml-6 leading-7' />
 }
-export const ToDoBlock = ({ Block,BlockType,Blockdata }) => {
+export const ToDoBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<ToDoBlockData>) => {
   const checkbox = Blockdata.checked;
   return <div className="pl-4">
   <input type="checkbox" checked={checkbox} className="pointer-events-none" readOnly/>
   <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} Tag="span" className="inline-block pl-1 leading-7" />
   </div>
 }
-export const ToggleBlock = ({ Block,BlockType,Blockdata }) => {
+export const ToggleBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<ToggleBlockData>) => {
   return <> 
     <details className='pl-4'>
       <summary>{Blockdata.rich_text[0].plain_text}</summary>
@@ -37,49 +38,49 @@ export const ToggleBlock = ({ Block,BlockType,Blockdata }) => {
     </details>
   </>
 }
-export const ImageBlock = ({ BlockType,Blockdata }) => {
+export const ImageBlock = ({ BlockType,Blockdata }: TextBlockProps<ImageBlockData>) => {
       const altText = Blockdata.caption.length > 0 ? Blockdata.caption[0].plain_text : "Notion Image";
       return <div data-type={BlockType}>
         <img src={Blockdata.file.url} alt={altText} />
       </div>
 }
-export const VideoBlock = ({ BlockType,Blockdata }) => {
+export const VideoBlock = ({ BlockType,Blockdata }: TextBlockProps<VideoBlockData>) => {
       return <div data-type={BlockType}>
         <video src={Blockdata.file.url}/>
       </div>
-}
-export const TableBlock = ({ Block,BlockType,Blockdata }) => {
+};
+export const TableBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<TableBlockData>) => {
   console.log('TableBlock Blockdata:', Block);
     return (
     <div className="max-w-2xl mx-auto">
-      <TableRows rows={Block.children} />
+      <TableRows rows={Block?.children ?? []} />
     </div>
   )
-}
-export const CodeBlock = ({ Block,BlockType,Blockdata }) => {
+};
+export const CodeBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<CodeBlockData>) => {
   return <pre>
       <code>
         <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata} className='py-6 px-8 border-[1px] border-border bg-surface rounded-2xl my-2 mx-4 leading-5'/>
       </code>
     </pre>
-}
-export const CalloutBlock = ({ Block,BlockType,Blockdata }) => {
+};
+export const CalloutBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<CalloutBlockData>) => {
   const Emoji = Blockdata.icon.emoji;
   return <div className='py-3 px-3 border-[1px] border-border bg-surface rounded-2xl mx-4 my-2'>
     {Emoji}<TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata}  className="inline-block pl-[5px] leading-7  "/>
   </div>
-}
-export const QuoteBlock = ({ Block,BlockType,Blockdata }) => {
+};
+export const QuoteBlock = ({ Block,BlockType,Blockdata }: TextBlockProps<QuoteBlockData>) => {
   return <blockquote className='py-3 px-3 border-l-[4px] border-text bg-surface mx-4 my-2'>
     <TextBlock Block={Block} BlockType={BlockType} Blockdata={Blockdata}  className=" "/>
   </blockquote>
-}
-export const DividerBlock = ({ Block,BlockType,Blockdata }) => {
+};
+export const DividerBlock = () => {
   return <hr className='border-white my-4 mx-4'/>
-}
-export const UnknownBlock = ({ Block,BlockType,Blockdata }) => {
-  return <></>
-}
+};
+export const UnknownBlock = () => {
+  return null
+};
 
 
 // 공통 텍스트 렌더링 컴포넌트 -> 링크 처리 포함
@@ -133,7 +134,8 @@ const BlockContent = ({ BlockText }: { BlockText: any[] }) => {
 
 
 // 공통 텍스트 렌더링 컴포넌트 -> 다양한 태그로 감싸기
-const TextBlock = ({ Block, BlockType, Blockdata, Tag = 'div', TagClass = '', className ='' }) => {
+const TextBlock = ({ Block, BlockType, Blockdata, Tag = 'div', TagClass = '', className ='' }
+  : { Block?: Block; BlockType: BlockType; Blockdata: any; Tag?: string; TagClass?: string; className?: string }) => {
   const BlockNum = Blockdata.rich_text.length;
   const BlockText = Blockdata.rich_text;
   const WrapperTag = Tag as any; 
@@ -150,7 +152,7 @@ const TextBlock = ({ Block, BlockType, Blockdata, Tag = 'div', TagClass = '', cl
         <BlockContent BlockText={BlockText} />
       </WrapperTag>
 
-      {Block.children?.length > 0 && (
+      {Block?.children && Block.children.length > 0 && (
         <>
           {Block.children.map((child: any) => (
             <RenderBlock key={child.id} block={child} />

--- a/src/components/NotionBlocks.type.ts
+++ b/src/components/NotionBlocks.type.ts
@@ -1,0 +1,99 @@
+
+export interface RichText {
+  type: 'text'
+  text: {
+    content: string
+    link: { url: string } | null
+  }
+  annotations: {
+    bold: boolean
+    italic: boolean
+    underline: boolean
+    strikethrough: boolean
+    code: boolean
+    color: string
+  }
+  plain_text: string
+}
+
+export interface ParagraphBlockData {
+  rich_text: RichText[]
+}
+
+export interface HeadingBlockData {
+  rich_text: RichText[]
+}
+
+export interface ListItemBlockData {
+  rich_text: RichText[]
+}
+
+export interface ToDoBlockData {
+  rich_text: RichText[]
+  checked: boolean
+}
+
+export type BlockType =
+  | 'paragraph'
+  | 'heading_1'
+  | 'heading_2'
+  | 'heading_3'
+  | 'bulleted_list_item'
+  | 'numbered_list_item'
+  | 'to_do'  
+  | 'toggle'
+  | 'image'
+  | 'video'
+  | 'table'
+  | 'code'
+  | 'callout'
+  | 'quote'
+  | 'divider'
+  | 'unknown'
+
+export interface Block {
+  id: string
+  type: BlockType
+  has_children: boolean
+  children?: Block[]
+}
+
+export interface TextBlockProps<T> {
+  Block?: Block
+  BlockType: BlockType
+  Blockdata: T
+}
+
+export interface ToggleBlockData {
+  rich_text: RichText[]
+}
+export interface FileObject {
+  url: string
+}
+
+export interface ImageBlockData {
+  caption: RichText[]
+  file: FileObject
+}
+export interface VideoBlockData {
+  file: FileObject
+}
+export interface TableBlockData {
+  table_width: number
+  has_column_header: boolean
+  has_row_header: boolean
+}
+export interface CodeBlockData {
+  rich_text: RichText[]
+  language: string
+}
+export interface CalloutBlockData {
+  rich_text: RichText[]
+  icon: {
+    emoji: string
+  }
+}
+export interface QuoteBlockData {
+  rich_text: RichText[]
+}
+export type EmptyBlockData = Record<string, never>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -16,53 +16,55 @@ export function ProjectCard({ page }: ProjectCardProps) {
 
   console.log('ProjectCard Props:', { page, title, tags, file, descriptions, URL, github });
   return (
-    <article className="rounded-2xl border border-border p-4 hover:shadow-sm transition">
-      <h3 className="text-lg font-semibold mb-2">
-        {title}
-      </h3>
-        {
-          file === '#' ? ( 
-          <p className="text-sm text-gray-500 mb-4">이미지 없음</p> 
-          ) : ( 
-            <img src={file} alt={title} className="w-full h-auto mb-4 rounded-lg object-cover"/>
-          )
-        }
-      <div className="flex flex-wrap gap-2">
-        {tags.map(tag => (
-          <span
-            key={tag}
-            className="text-xs px-2 py-1 rounded-full bg-surface border border-border"
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
-      
-      <div className="flex flex-wrap gap-2">
-          <ul className="list-disc list-inside" >
-            {descriptions.map(des => (
-                <li key={des}>
-                  <span
-                    className="text-xs "
-                  >
-                    {des}
-                  </span>
-                </li>
-            ))}
-          </ul>
-      </div>
-      <div>
-        { URL !== '#' && 
-          <Link href={URL} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline mr-4">
-            프로젝트 링크
+    <article className="p-4 w-1/3">
+      <div className="rounded-2xl border border-border p-4 hover:shadow-sm  transition">
+        <h3 className="text-lg font-semibold mb-2">
+          {title}
+        </h3>
+          {
+            file === '#' ? ( 
+            <p className="text-sm text-gray-500 mb-4">이미지 없음</p> 
+            ) : ( 
+              <img src={file} alt={title} className="w-full h-auto mb-4 rounded-lg object-cover"/>
+            )
+          }
+        <div className="flex flex-wrap gap-2">
+          {tags.map(tag => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-1 rounded-full bg-surface border border-border"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+        
+        <div className="flex flex-wrap gap-2">
+            <ul className="list-disc list-inside" >
+              {descriptions.map(des => (
+                  <li key={des}>
+                    <span
+                      className="text-xs "
+                    >
+                      {des}
+                    </span>
+                  </li>
+              ))}
+            </ul>
+        </div>
+        <div>
+          { URL !== '#' && 
+            <Link href={URL} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline mr-4">
+              프로젝트 링크
+            </Link>
+          }
+          
+          { github !== '#' && 
+          <Link href={github} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+            GitHub
           </Link>
         }
-        
-        { github !== '#' && 
-        <Link href={github} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-          GitHub
-        </Link>
-      }
+        </div>
       </div>
     </article>
   )

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,69 @@
+import { NotionPage } from "@/hooks/useNotionApi.type"
+import Link from "next/link";
+
+interface ProjectCardProps {
+  page: NotionPage
+}
+
+export function ProjectCard({ page }: ProjectCardProps) {
+  // 아래와 같이 각각의 속성 추출 함수 사용 복잡한 데이터 구조로 디버깅 용이
+  const title = page.properties['title']?.title?.[0]?.plain_text || '제목 없음'
+  const tags = page.properties['tool']?.multi_select?.map((t: { name: any; }) => t.name) || []
+  const file = page.properties['file']?.files?.[0]?.file?.url || '#'
+  const descriptions = page.properties['description']?.multi_select?.map((t: { name: any; }) => t.name) || []
+  const URL = page.properties['URL']?.url || '#'
+  const github = page.properties['git']?.url || '#'
+
+  console.log('ProjectCard Props:', { page, title, tags, file, descriptions, URL, github });
+  return (
+    <article className="rounded-2xl border border-border p-4 hover:shadow-sm transition">
+      <h3 className="text-lg font-semibold mb-2">
+        {title}
+      </h3>
+        {
+          file === '#' ? ( 
+          <p className="text-sm text-gray-500 mb-4">이미지 없음</p> 
+          ) : ( 
+            <img src={file} alt={title} className="w-full h-auto mb-4 rounded-lg object-cover"/>
+          )
+        }
+      <div className="flex flex-wrap gap-2">
+        {tags.map(tag => (
+          <span
+            key={tag}
+            className="text-xs px-2 py-1 rounded-full bg-surface border border-border"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+      
+      <div className="flex flex-wrap gap-2">
+          <ul className="list-disc list-inside" >
+            {descriptions.map(des => (
+                <li key={des}>
+                  <span
+                    className="text-xs "
+                  >
+                    {des}
+                  </span>
+                </li>
+            ))}
+          </ul>
+      </div>
+      <div>
+        { URL !== '#' && 
+          <Link href={URL} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline mr-4">
+            프로젝트 링크
+          </Link>
+        }
+        
+        { github !== '#' && 
+        <Link href={github} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+          GitHub
+        </Link>
+      }
+      </div>
+    </article>
+  )
+}

--- a/src/hooks/useNotionApi.ts
+++ b/src/hooks/useNotionApi.ts
@@ -1,9 +1,10 @@
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import axios from 'axios'
+import { NotionPage, ProjectSubType, PROJECT_SUB_TYPES } from './useNotionApi.type'
 
 export function useNotionApi(params?: Record<string, string | boolean>) {
-  const [notes, setNotes] = useState<any[]>([])
+  const [notes, setNotes] = useState<NotionPage[]>([])
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
@@ -11,9 +12,9 @@ export function useNotionApi(params?: Record<string, string | boolean>) {
     const fetchNotes = async () => {
       setLoading(true)
       try {
-        const res = await axios.get('/api/notion', { params })
+        const res = await axios.get<NotionPage[]>('/api/notion', { params })
         setNotes(res.data)
-        console.log('✅ Notion API Response:', res.data)
+        // console.log('✅ Notion API Response:', res.data);
       } catch (err) {
         console.error(err)
         setError('🚨 Notion 데이터를 불러오지 못했습니다.')
@@ -26,4 +27,82 @@ export function useNotionApi(params?: Record<string, string | boolean>) {
   }, [JSON.stringify(params)]) // 파라미터 변경 시 재요청
 
   return { notes, error, loading }
+}
+
+
+
+// 해당type[0] 포함시 분류 배출   
+export function useNotionProjectNotes(tag: string) {
+  const { notes, loading, error } = useNotionApi()
+
+  const projectNotes = useMemo(() => {
+    return notes.filter(page =>
+      Object.values(page.properties).some(prop =>
+        prop.type === 'multi_select' &&
+        prop.multi_select?.some(item => item.name === tag)
+      )
+    )
+  }, [notes, tag])
+
+  // console.log('Filtered Project Notes:', projectNotes);
+  return {
+    projectNotes,
+    loading,
+    error,
+  }
+}
+
+
+// 해당type[0] 포함시 type[1] 으로 분류 배출   
+
+
+export function useNotionProjectNotesTabs(tag: string) {
+  const { notes, loading, error } = useNotionApi()
+
+  const result = useMemo(() => {
+    const grouped: Record<ProjectSubType, typeof notes> = {
+      PUBLISHING: [],
+      WEBDESIGN: [],
+      LOGO: [],
+      FRONTEND: [],
+      ETC: [],
+    }
+
+    notes.forEach(page => {
+      const multiSelectProp = Object.values(page.properties).find(
+        prop => prop.id === 'rJw%5D' 
+      )
+
+      if (!multiSelectProp?.multi_select) return
+
+      // PROJECT 포함 여부
+      const hasProject = multiSelectProp.multi_select.some(
+        t => t.name === tag
+      )
+      // console.log('Page Multi-Selects:', multiSelectProp.multi_select);
+      if (!hasProject) return
+
+      // PROJECT 제외한 서브 타입
+      const subType = multiSelectProp.multi_select.find(
+        t => t.name !== tag
+      )?.name as ProjectSubType | undefined
+
+      // 🚨 화이트리스트에 없는 타입은 버림
+      if (!subType || !PROJECT_SUB_TYPES.includes(subType)) return
+
+      grouped[subType].push(page)
+    })
+
+    return {
+      tabs: PROJECT_SUB_TYPES,
+      groupedNotes: grouped,
+    }
+  }, [notes, tag])
+
+  return {
+    tabs: result.tabs,
+    groupedNotes: result.groupedNotes,
+    loading,
+    error,
+  }
 }

--- a/src/hooks/useNotionApi.type.ts
+++ b/src/hooks/useNotionApi.type.ts
@@ -1,0 +1,30 @@
+
+export interface NotionMultiSelect {
+  id: string
+  name: string
+  color: string
+}
+
+export interface NotionProperty {
+  tool: string
+  files: any
+  title: any
+  id: string
+  type: string
+  multi_select?: NotionMultiSelect[]
+}
+
+export interface NotionPage {
+  file: any
+  id: string
+  properties: Record<string, NotionProperty>
+}
+
+export interface NotionResponse {
+  results: NotionPage[]
+}
+
+
+export const PROJECT_SUB_TYPES = ['PUBLISHING', 'WEBDESIGN', 'LOGO', 'FRONTEND', 'ETC'] as const
+
+export type ProjectSubType = typeof PROJECT_SUB_TYPES[number]

--- a/src/utils/notionToMarkdown.tsx
+++ b/src/utils/notionToMarkdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { JSX } from 'react';
 import {
   ParagraphBlock,
   Heading1Block,
@@ -33,12 +33,12 @@ const BLOCK_RENDERERS: Record<string, (block: any) => JSX.Element> = {
   code: (b) => <CodeBlock Block={b} BlockType={b.type} Blockdata={b[b.type]} />,
   callout: (b) => <CalloutBlock Block={b} BlockType={b.type} Blockdata={b[b.type]} />,
   quote: (b) => <QuoteBlock Block={b} BlockType={b.type} Blockdata={b[b.type]} />,
-  divider: (b) => <DividerBlock Block={b} BlockType={b.type} Blockdata={b[b.type]} />,
+  divider: (b) => <DividerBlock />,
 }
 
 
 export function RenderBlock({ block }: { block: any }) {
   const Renderer = BLOCK_RENDERERS[block.type]
-  return Renderer ? Renderer(block) : <UnknownBlock block={block} />
+  return Renderer ? Renderer(block) : <UnknownBlock />
 }
 


### PR DESCRIPTION
## 📌 프로젝트 분류 탭 지정 및 노션 데이터 타입지정 및 테스트

---

## 📝 작업 내용 요약

- [x]  **`PROJECT`** 타입이 포함된 데이터만 1차 필터링
- [x]  **`PROJECT`** 외 서브 타입 기준으로 2차 분류 후 탭 형태로 노출
- [x]  탭 클릭 시 해당 분류의 프로젝트 카드만 렌더링
- [x]  동일 로직이 다른 분류에도 재사용 가능한지 확인
- [x]  **`ProjectCard`** 컴포넌트 구현
---

## 🧠 구현 상세 내용

> 핵심 로직, 의도, 주요 변경 사항 등을 자세히 설명해주세요.
- [x]  카드에 필요한 데이터(title, tags, file, description, URL, GitHub 등) 추출
    → URL / GitHub 값이 없는 경우 UI 미노출 처리
- [x]  Notion 데이터 구조에 맞춰 타입을 `.type.ts` 파일로 분리 정의
- [x]  `useNotionProjectNotes`
    → `PROJECT` 타입 기준 **1차 필터링**된 데이터만 반환
- [x]  `useNotionProjectNotesTabs`
    → 1차 필터링된 데이터를 기준으로
    서브 타입별 **2차 분류 + 탭 UI에 바로 사용 가능한 형태로 가공**
- [x]  Notion 태그 순서에 의존하지 않고,
    `PROJECT`를 제외한 나머지 타입을 서브 타입으로 판단하여 안정성 확보
 
---

## 🧪 테스트 항목
> 확인이 필요한 부분이나 직접 테스트한 시나리오를 적어주세요.

- [x] 데이터 구조에 복잡함이 있어 찾고자하는 테이터 분류를 잘가져오는지, 분류는 잘 되었는지 확인
- [x] 복잡한 구조가 어느정도 속도로 불러와지는지 확인 -> 배포전이기 때문에 불확실
- [x]  useNotionProjectNotes 다른 카테고리일 경우 잘 작동하는지 확인

---

## 🎨 UI 변경사항 (선택)
> UI 변경이 있는 경우 스크린샷이나 GIF 첨부해주세요.

<img width="917" height="801" alt="Create-Next-App" src="https://github.com/user-attachments/assets/23c12d21-d3e9-4dcc-906c-eddb9b628c65" />
<img width="917" height="801" alt="Create-Next-App" src="https://github.com/user-attachments/assets/35bd58b2-5e80-410c-80f6-05180de44131" />

---

## 📎 관련 이슈
> #8 

closes #

---

## 💬 기타 참고 사항
> 코드 리뷰어가 알아야 할 특이사항, TODO, 리팩토링 계획 등을 적어주세요.

- [ ]  디자인 예정
- [ ]  해당카드 클릭시에서는 팝업으로 표현  예정
- [ ]  팝업디자인 예정
- [ ] 디자인 후 배포 테스트


